### PR TITLE
fix: return fn symbol from generated body

### DIFF
--- a/src/ghostwheel/core.cljc
+++ b/src/ghostwheel/core.cljc
@@ -1053,8 +1053,7 @@
                               (if (= trace 1)
                                 traced-defn
                                 (clairvoyant-trace traced-defn trace color env))))]
-    `(do ~fdef ~traced-defn ~main-defn ~instrumentation ~generated-test)))
-
+    `(do ~fdef ~traced-defn ~main-defn ~instrumentation ~generated-test ~fn-name)))
 
 (defn after-check-async [done]
   (let [success @r/*all-tests-successful]


### PR DESCRIPTION
This commit changes the `generate-defn` return value to be the symbol of
the newly generated function name. This is inline with the behavior of
`clojure.core/defn` and `clojure.core/defn-`.

The reason this is useful is because some tools (namely cider / nrepl) rely on
the return value of the `defn` for certain functionality, such as
debugging and tracing. By returning the symbol, those tools go back to
working with ghostwheel generated functions.