### PR TITLE
Fix #33: Add >defmethod

### DIFF
--- a/src/ghostwheel/core.cljc
+++ b/src/ghostwheel/core.cljc
@@ -1273,6 +1273,22 @@
             (cljs-env? &env) clj->cljs)
     (clean-defn 'defn- forms)))
 
+(defmacro >defmethod
+  "Like defmethod, but requires a (nilable) gspec definition and generates
+  additional `s/fdef`, generative tests, instrumentation code, an
+  fspec-based stub, and/or tracing code, depending on the configuration
+  metadata and the existence of a valid gspec and non-nil body."
+  [multifn dispatch-val argv gspec & body]
+  (let [delegate-defn-name (symbol (str multifn "_" (gensym)))]
+    `(do
+       (>defn ~delegate-defn-name
+         ~argv
+         ~gspec
+         ~@body)
+       (defmethod ~multifn
+         ~dispatch-val
+         ~argv
+         (~delegate-defn-name ~@argv)))))
 
 (defmacro after-check
   "Takes a number of 0-arity functions to run


### PR DESCRIPTION
This PR fixes #33

Example:

```clojure
(defmulti demo pos?)

(>defmethod demo
  true
  [x]
  [pos? => nil?]
  (println "It's positive"))

(>defmethod demo
  false
  [x]
  [(s/or :zero zero? :neg neg?) => nil?]
  (println "It's zero or negative!"))

(demo 1)
;; => "It's positive"

(demo -3)
;; => "It's zero or negative!"
```

It achieves this by delegating to `>defn`:

```clojure
(do
 (>defn demo_G__20347
  [x]
  [pos? => nil?]
  (println "It's positive"))
 (defmethod demo 
   true
   [x]
   (demo_G__20347 x)))

(do
 (>defn demo_G__20352
  [x]
  [(s/or :zero zero? :neg neg?) => nil?]
  (println "It's zero or negative!"))
 (defmethod demo
   false
   [x]
   (demo_G__20352 x)))
```